### PR TITLE
docs: update SonarCloud badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@
         <a href="https://github.com/process-analytics/bpmn-visualization-addons/actions">
           <img alt="Build" src="https://github.com/process-analytics/bpmn-visualization-addons/workflows/Build/badge.svg"> 
         </a>
-        <a href="https://sonarcloud.io/project/overview?id=process-analytics_bv-experimental-add-ons">
-          <img alt="Coverage" src="https://sonarcloud.io/api/project_badges/measure?project=process-analytics_bv-experimental-add-ons&metric=code_smells">
+        <a href="https://sonarcloud.io/project/overview?id=process-analytics_bpmn-visualization-addons">
+          <img alt="Code Smells" src="https://sonarcloud.io/api/project_badges/measure?project=process-analytics_bpmn-visualization-addons&metric=code_smells">
         </a>
         <br>
         <a href=https://github.com/process-analytics/.github/blob/main/CODE_OF_CONDUCT.md">


### PR DESCRIPTION
Use the new project key that matches the new repository name.
The project was no longer found when using the old project key.

Covers #310
