### PR TITLE
refactor: improve internal types based on SonarCloud feedback

### DIFF
--- a/packages/addons/src/bpmn-elements.ts
+++ b/packages/addons/src/bpmn-elements.ts
@@ -129,7 +129,7 @@ export class BpmnElementsIdentifier {
 }
 
 export class ShapeUtil extends BaseShapeUtil {
-  static isBpmnArtifact = (kind: ShapeBpmnElementKind | string): boolean => {
+  static isBpmnArtifact(kind: ShapeBpmnElementKind | string): boolean {
     return kind === ShapeBpmnElementKind.GROUP || kind === ShapeBpmnElementKind.TEXT_ANNOTATION;
-  };
+  }
 }

--- a/packages/addons/src/plugins-support.ts
+++ b/packages/addons/src/plugins-support.ts
@@ -80,7 +80,7 @@ export class BpmnVisualization extends BaseBpmnVisualization {
     return this.plugins.get(id) as T;
   }
 
-  private registerPlugins = (options: GlobalOptions): void => {
+  private readonly registerPlugins = (options: GlobalOptions): void => {
     // construct
     for (const constructor of options.plugins ?? []) {
       const plugin = new constructor(this, options);

--- a/packages/demo/src/shared/zoom-component.ts
+++ b/packages/demo/src/shared/zoom-component.ts
@@ -48,8 +48,8 @@ const addDomElement = (): HTMLDivElement => {
 export class ZoomComponent {
   private isRendered = false;
   constructor(
-    private bpmnVisualization: BpmnVisualization,
-    private fitOptions: FitOptions,
+    private readonly bpmnVisualization: BpmnVisualization,
+    private readonly fitOptions: FitOptions,
   ) {}
 
   render(): void {


### PR DESCRIPTION
Mainly mark properties and methods as readonly when possible.