### PR TITLE
refactor!: rename the package to `bpmn-visualization-addons`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,7 +19,7 @@ updates:
     reviewers:
       - process-analytics/pa-collaborators
     ignore:
-      # typescript must not be updated in packages/check-ts-support. Its version must remain unchanged to test the minimum version supported by bv-addons
+      # typescript must not be updated in packages/check-ts-support. Its version must remain unchanged to test the minimum version supported by bpmn-visualization-addons
       # For more details, see:
       #    https://github.com/process-analytics/bpmn-visualization-addons/pull/90
       #    https://github.com/process-analytics/bpmn-visualization-addons/pull/92

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <h1 align="center">bpmn-visualization-addons</h1>
 <div align="center">
     <p align="center"> 
-        <a href="https://npmjs.org/package/@process-analytics/bv-experimental-add-ons">
-          <img alt="npm package" src="https://img.shields.io/npm/v/@process-analytics/bv-experimental-add-ons.svg?color=orange"> 
+        <a href="https://npmjs.org/package/@process-analytics/bpmn-visualization-addons">
+          <img alt="npm package" src="https://img.shields.io/npm/v/@process-analytics/bpmn-visualization-addons.svg?color=orange"> 
         </a> 
         <a href="https://github.com/process-analytics/bpmn-visualization-addons/releases">
           <img alt="GitHub release (latest by date including pre-releases)" src="https://img.shields.io/github/v/release/process-analytics/bpmn-visualization-addons?label=changelog&include_prereleases"> 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2035,7 +2035,7 @@
         "url": "https://opencollective.com/unts"
       }
     },
-    "node_modules/@process-analytics/bv-experimental-add-ons": {
+    "node_modules/@process-analytics/bpmn-visualization-addons": {
       "resolved": "packages/addons",
       "link": true
     },
@@ -12151,7 +12151,7 @@
       }
     },
     "packages/addons": {
-      "name": "@process-analytics/bv-experimental-add-ons",
+      "name": "@process-analytics/bpmn-visualization-addons",
       "version": "0.7.1",
       "license": "Apache-2.0",
       "devDependencies": {

--- a/packages/addons/README.md
+++ b/packages/addons/README.md
@@ -34,7 +34,7 @@ The `@process-analytics/bpmn-visualization-addons` npm package includes type def
 The plugins infrastructure provides a way to register extension points.
 
 > [!IMPORTANT]  
-> To be able to register and use the plugins, you need to import `BpmnVisualization` from the `addons` package, and not from `bpmn-visualization`.
+> To be able to register and use the plugins, you need to import `BpmnVisualization` from `bpmn-visualization-addons`, and not from `bpmn-visualization`.
 ```diff
 - import {BpmnVisualization} from "bpmn-visualization";
 + import {BpmnVisualization} from "@process-analytics/bpmn-visualization-addons";

--- a/packages/addons/README.md
+++ b/packages/addons/README.md
@@ -6,14 +6,24 @@
 ## 📌 Usage
 
 Install `bpmn-visualization-addons` and [bpmn-visualization](https://github.com/process-analytics/bpmn-visualization-js/):
-```shell script
-npm i @process-analytics/bv-experimental-add-ons bpmn-visualization
+```shell
+npm install @process-analytics/bpmn-visualization-addons bpmn-visualization
 ```
 
+> [!NOTE]  
+> Until version 0.7.1, the `bpmn-visualization-addons` package was available under the name `bv-experimental-add-ons`.
+If your application was using the package under its former name, proceed as follows:
+```shell
+# first uninstall the old package
+npm uninstall @process-analytics/bv-experimental-add-ons
+# then install the new package
+npm install @process-analytics/bpmn-visualization-addons
+```
+Then, update the imports in your application code to use the new package name.
 
 ## 📜 TypeScript Support
 
-The `@process-analytics/bv-experimental-add-ons` npm package includes type definitions, so the integration works out of the box in TypeScript projects and applications.
+The `@process-analytics/bpmn-visualization-addons` npm package includes type definitions, so the integration works out of the box in TypeScript projects and applications.
 `bpmn-visualization-addons` requires **TypeScript 4.5** or greater.
 
 
@@ -27,13 +37,13 @@ The plugins infrastructure provides a way to register extension points.
 > To be able to register and use the plugins, you need to import `BpmnVisualization` from the `addons` package, and not from `bpmn-visualization`.
 ```diff
 - import {BpmnVisualization} from "bpmn-visualization";
-+ import {BpmnVisualization} from "@process-analytics/bv-experimental-add-ons";
++ import {BpmnVisualization} from "@process-analytics/bpmn-visualization-addons";
 ```
 
 Example of use:
 
 ```ts
-import {BpmnVisualization} from "@process-analytics/bv-experimental-add-ons";
+import {BpmnVisualization} from "@process-analytics/bpmn-visualization-addons";
 
 const bpmnVisualization = new BpmnVisualization({
     container: 'bpmn-container',

--- a/packages/addons/README.md
+++ b/packages/addons/README.md
@@ -12,14 +12,18 @@ npm install @process-analytics/bpmn-visualization-addons bpmn-visualization
 
 > [!NOTE]  
 > Until version 0.7.1, the `bpmn-visualization-addons` package was available under the name `bv-experimental-add-ons`.
-If your application was using the package under its former name, proceed as follows:
+If your application was using the package under its former name, proceed as follows 👇:
 ```shell
 # first uninstall the old package
 npm uninstall @process-analytics/bv-experimental-add-ons
 # then install the new package
 npm install @process-analytics/bpmn-visualization-addons
 ```
-Then, update the imports in your application code to use the new package name.
+Then, update the imports in your application code to use the new package name as follows 👇:
+```diff
+- import {BpmnVisualization} from "@process-analytics/bv-experimental-add-ons";
++ import {BpmnVisualization} from "@process-analytics/bpmn-visualization-addons";
+```
 
 ## 📜 TypeScript Support
 

--- a/packages/addons/package.json
+++ b/packages/addons/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@process-analytics/bv-experimental-add-ons",
+  "name": "@process-analytics/bpmn-visualization-addons",
   "version": "0.7.1",
   "private": false,
   "type": "module",

--- a/packages/check-ts-support/src/index.ts
+++ b/packages/check-ts-support/src/index.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { BpmnElementsIdentifier, PathResolver } from '@process-analytics/bv-experimental-add-ons';
+import { BpmnElementsIdentifier, PathResolver } from '@process-analytics/bpmn-visualization-addons';
 import { BpmnVisualization } from 'bpmn-visualization';
 
 // bpmn-visualization

--- a/packages/demo/src/overlays.ts
+++ b/packages/demo/src/overlays.ts
@@ -17,7 +17,7 @@ limitations under the License.
 import './assets/overlays.css';
 import type { FitOptions } from 'bpmn-visualization';
 
-import { BpmnVisualization, OverlaysPlugin } from '@process-analytics/bv-experimental-add-ons';
+import { BpmnVisualization, OverlaysPlugin } from '@process-analytics/bpmn-visualization-addons';
 import { FitType } from 'bpmn-visualization';
 
 import { fetchDiagram } from './shared/diagrams.js';

--- a/packages/demo/src/path-resolver.ts
+++ b/packages/demo/src/path-resolver.ts
@@ -17,7 +17,7 @@ limitations under the License.
 import './assets/path-resolver.css';
 import type { BpmnElement } from 'bpmn-visualization';
 
-import { BpmnVisualization, ElementsPlugin, PathResolver, ShapeUtil, StylePlugin } from '@process-analytics/bv-experimental-add-ons';
+import { BpmnVisualization, ElementsPlugin, PathResolver, ShapeUtil, StylePlugin } from '@process-analytics/bpmn-visualization-addons';
 import { FitType } from 'bpmn-visualization';
 
 import { fetchDiagram } from './shared/diagrams.js';

--- a/packages/demo/src/plugins-by-name.ts
+++ b/packages/demo/src/plugins-by-name.ts
@@ -18,7 +18,7 @@ import './assets/plugins-by-name.css';
 
 import type { FitOptions, StyleUpdate } from 'bpmn-visualization';
 
-import { BpmnVisualization, StyleByNamePlugin } from '@process-analytics/bv-experimental-add-ons';
+import { BpmnVisualization, StyleByNamePlugin } from '@process-analytics/bpmn-visualization-addons';
 import { FitType } from 'bpmn-visualization';
 
 import { fetchDiagram } from './shared/diagrams.js';


### PR DESCRIPTION
Update the package.json attribute to ensure that the package will be published under its new name.
Update the rest of the code and the documentation accordingly to prepare the new release.

BREAKING CHANGES: this package renaming requires updating the dependency declaration and imports in the code.