### PR TITLE
style: apply typescript-eslint stylistic rules

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -56,6 +56,7 @@ module.exports = {
       files: ['*.ts'],
       extends: [
         'plugin:@typescript-eslint/recommended', // Uses the recommended rules from the @typescript-eslint/eslint-plugin
+        'plugin:@typescript-eslint/stylistic',
         'plugin:import/typescript',
         'plugin:prettier/recommended', // Enables eslint-plugin-prettier and eslint-config-prettier. This will display prettier errors as ESLint errors. Make sure this is always the last configuration in the extends array.
       ],

--- a/packages/addons/src/bpmn-elements.ts
+++ b/packages/addons/src/bpmn-elements.ts
@@ -23,12 +23,12 @@ const allBpmnElementKinds: BpmnElementKind[] = [...Object.values(ShapeBpmnElemen
 /**
  * Options to deduplicate elements when several names match.
  */
-export type DeduplicateNamesOptions = {
+export interface DeduplicateNamesOptions {
   /** If not set, use all `BpmnElementKind` values. */
   kinds?: BpmnElementKind[];
   /** Apply custom function to filter duplicates. */
   filter?: (bpmnSemantic: BpmnSemantic) => boolean;
-};
+}
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const acceptAll = (_bpmnSemantic: BpmnSemantic): boolean => true;

--- a/packages/addons/src/paths.ts
+++ b/packages/addons/src/paths.ts
@@ -88,7 +88,7 @@ export class CasePathResolver {
   }
 }
 
-export type CasePathResolverInput = {
+export interface CasePathResolverInput {
   /**
    * The IDs of elements (flowNodes/shapes and flows/edges) that are already completed. Non-existing ids will be silently ignored.
    *
@@ -96,9 +96,9 @@ export type CasePathResolverInput = {
    * No further user action or automation will update the element.
    */
   completedIds: string[];
-};
+}
 
-export type CasePathResolverOutput = {
+export interface CasePathResolverOutput {
   /**
    * The `BpmnSemantic` objects retrieved from the model that relate to the ids passed in {@link CasePathResolverInput}.
    */
@@ -114,4 +114,4 @@ export type CasePathResolverOutput = {
       edges: EdgeBpmnSemantic[];
     };
   };
-};
+}

--- a/packages/addons/src/plugins-support.ts
+++ b/packages/addons/src/plugins-support.ts
@@ -51,9 +51,9 @@ export interface Plugin {
  *
  * If you don't extend `GlobalOptions`, use {@link GlobalOptions} directly.
  */
-export type PluginOptionExtension = {
+export interface PluginOptionExtension {
   plugins?: PluginConstructor[];
-};
+}
 
 export type GlobalOptions = BaseGlobalOptions & PluginOptionExtension;
 
@@ -69,7 +69,7 @@ export type DefaultPlugins = 'css' | 'elements' | 'overlays' | 'style' | 'style-
 export type PluginIds = DefaultPlugins | (string & Record<never, never>);
 
 export class BpmnVisualization extends BaseBpmnVisualization {
-  private readonly plugins: Map<string, Plugin> = new Map();
+  private readonly plugins = new Map<string, Plugin>();
 
   constructor(options: GlobalOptions) {
     super(options);

--- a/packages/addons/src/plugins/style.ts
+++ b/packages/addons/src/plugins/style.ts
@@ -100,7 +100,7 @@ export class StyleByNamePlugin implements Plugin, StyleRegistryByName {
   }
 
   updateStyle(bpmnElementNames: string | string[], styleUpdate: StyleUpdate): void {
-    const bpmnElements = this.searcher.getElementsByNames(bpmnElementNames as Array<string>);
+    const bpmnElements = this.searcher.getElementsByNames(bpmnElementNames as string[]);
     this.styleRegistry.updateStyle(
       bpmnElements.map(bpmnElement => bpmnElement.id),
       styleUpdate,
@@ -112,7 +112,7 @@ export class StyleByNamePlugin implements Plugin, StyleRegistryByName {
       this.styleRegistry.resetStyle();
       return;
     }
-    const bpmnElements = this.searcher.getElementsByNames(bpmnElementNames as Array<string>);
+    const bpmnElements = this.searcher.getElementsByNames(bpmnElementNames as string[]);
     this.styleRegistry.resetStyle(bpmnElements.map(bpmnElement => bpmnElement.id));
   }
 }

--- a/packages/addons/test/spec/plugins/overlays.test.ts
+++ b/packages/addons/test/spec/plugins/overlays.test.ts
@@ -206,9 +206,9 @@ class OverlaysExpectation {
 // The real type is "class MxGraphCustomOverlay extends mxgraph.mxCellOverlay" but it is not part of the API so create a convenient matching type here
 // class BpmnVisualizationOverlay extends mxCellOverlay {}
 // In tests in this file, we are only checking the label, so use a simple type matching the label property of the actual type.
-type BpmnVisualizationOverlay = {
+interface BpmnVisualizationOverlay {
   label: string;
-};
+}
 
 function createOverlay(label: string): Overlay {
   return { label, position: 'top-center' };

--- a/packages/demo/src/plugins-by-name.ts
+++ b/packages/demo/src/plugins-by-name.ts
@@ -45,7 +45,7 @@ function clearAllStyles(): void {
   styleRegistryByName.resetStyle();
 }
 
-function pickRandomElement<T>(array: Array<T>): T {
+function pickRandomElement<T>(array: T[]): T {
   return array[Math.floor(Math.random() * array.length)];
 }
 

--- a/packages/demo/vite.config.ts
+++ b/packages/demo/vite.config.ts
@@ -28,9 +28,9 @@ function findFiles(relativePathToSourceDirectory: string): string[] {
 }
 // =====================================================================================================================
 
-function generateInput(): { [p: string]: string } {
+function generateInput(): Record<string, string> {
   const pages = findFiles('pages');
-  const input: { [p: string]: string } = {
+  const input: Record<string, string> = {
     index: path.resolve(path.dirname(fileURLToPath(import.meta.url)), 'index.html'),
   };
   for (const page of pages) {


### PR DESCRIPTION
The sole public visible change is the use of interface instead of type.
This follows generally accepted standards in TypeScript projects.
The final definition interfaces can result from the merge from difference locations, so it eases extensions.